### PR TITLE
release-sync: use targeted Vitest project runner

### DIFF
--- a/scripts/thinkscape-upstream-release-sync.sh
+++ b/scripts/thinkscape-upstream-release-sync.sh
@@ -342,7 +342,7 @@ main() {
   # Keep release validation scoped to the fork-managed patch surfaces.
   # The broader loadConfig/temp-home suites have upstream hangs on v2026.4.5
   # and are not specific to the release patch set being applied here.
-  pnpm vitest run \
+  node scripts/test-projects.mjs \
     src/config/zod-schema.session-maintenance-extensions.test.ts \
     src/agents/openclaw-tools.subagents.sessions-spawn-gateway-timeout.test.ts \
     src/agents/session-write-lock.test.ts


### PR DESCRIPTION
## Summary
- switch release-sync validation from raw `pnpm vitest run` to `node scripts/test-projects.mjs`
- avoid the new upstream Vitest workspace duplicate-project startup failure
- keep the validation scoped to the three Thinkscape-managed patch tests

## Why
The upstream `v2026.4.20` layout moved to the `test/vitest/*` project runner flow.
Running bare `pnpm vitest run ...` during `thinkscape-upstream-release-sync` now fails before tests execute with duplicate project-name errors.

This change makes the automation use the repo's current targeted test runner so future upstream syncs can validate the patch surfaces successfully.

## Related
- fixes follow-up automation after #8
