### PR TITLE
release-sync: drop unsupported setup-node-env input

### DIFF
--- a/.github/workflows/thinkscape-upstream-release-sync.yml
+++ b/.github/workflows/thinkscape-upstream-release-sync.yml
@@ -41,7 +41,6 @@ jobs:
           pnpm-version: "10.32.1"
           install-bun: "false"
           install-deps: "false"
-          use-sticky-disk: "false"
 
       - name: Configure Git author
         run: |


### PR DESCRIPTION
## Summary
- remove the unsupported `use-sticky-disk` input from the upstream sync workflow
- eliminate the GitHub Actions warning emitted on every sync run

## Why
The local composite action no longer accepts this input. Keeping the workflow aligned avoids noisy warnings during future automated upstream syncs.
